### PR TITLE
Fix error handling in sharded inference

### DIFF
--- a/pkg/tsetlin/sharded_inference.go
+++ b/pkg/tsetlin/sharded_inference.go
@@ -125,10 +125,10 @@ func (si *ShardedInference) PredictBatchParallelWithCallbackAndError(X [][]float
 			<-workerChan
 			defer func() { workerChan <- 0 }()
 			predictions[i] = si.Predict(X[i])
-			if err := callback(i, si.machines[predictions[i]]); err != nil {
+			if cbErr := callback(i, si.machines[predictions[i]]); cbErr != nil {
 				mu.Lock()
 				if err == nil {
-					err = err
+					err = cbErr
 				}
 				mu.Unlock()
 			}


### PR DESCRIPTION
## Summary
- correct variable use when collecting callback errors in `ShardedInference`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683ffece7ea083229b422edc233da38c